### PR TITLE
cmake: allow building SharedLibrary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,16 @@ cmake_minimum_required(VERSION 3.27)
 
 project(fcitx5-beast VERSION 0.1.0)
 
+include(GNUInstallDirs)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(ENABLE_TEST "Build Test" On)
+set(ADDON_TYPE "StaticLibrary" CACHE STRING "StaticLibrary or SharedLibrary")
+
+if (NOT "${ADDON_TYPE}" MATCHES "^(StaticLibrary|SharedLibrary)$")
+  message(FATAL_ERROR "ADDON_TYPE must be StaticLibrary or SharedLibrary")
+endif()
 
 find_package(Gettext REQUIRED)
 find_package(Fcitx5Core 5 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,17 @@
-add_library(beast STATIC beast.cpp)
-target_link_libraries(beast Fcitx5::Core)
+
+if (${ADDON_TYPE} STREQUAL "StaticLibrary")
+    add_library(beast STATIC beast.cpp)
+    target_link_libraries(beast Fcitx5::Core)
+endif()
+
+if (${ADDON_TYPE} STREQUAL "SharedLibrary")
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    add_library(beast SHARED beast.cpp)
+    target_link_libraries(beast Fcitx5::Core)
+    target_compile_definitions(beast PUBLIC FCITX_BEAST_IS_SHARED)
+    install(TARGETS beast DESTINATION "${CMAKE_INSTALL_LIBDIR}/fcitx5")
+endif()
+
 configure_file(beast.conf.in.in beast.conf.in @ONLY)
 fcitx5_translate_desktop_file(${CMAKE_CURRENT_BINARY_DIR}/beast.conf.in beast.conf)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/beast.conf" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/fcitx5/addon")

--- a/src/beast.conf.in.in
+++ b/src/beast.conf.in.in
@@ -4,6 +4,6 @@ Comment=Interact with fcitx5 via HTTP, powered by Boost.Beast
 Category=Module
 Version=@PROJECT_VERSION@
 Library=libbeast
-Type=StaticLibrary
+Type=@ADDON_TYPE@
 OnDemand=False
 Configurable=True

--- a/src/beast.cpp
+++ b/src/beast.cpp
@@ -172,3 +172,7 @@ void Beast::stopThread() {
     serverThread_.join();
 }
 } // namespace fcitx
+
+#ifdef FCITX_BEAST_IS_SHARED
+FCITX_ADDON_FACTORY(fcitx::BeastFactory)
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(testbeast testbeast.cpp)
-target_link_libraries(testbeast Fcitx5::Core beast)
+target_link_libraries(testbeast $<TARGET_OBJECTS:beast> Fcitx5::Core)
 add_test(NAME testbeast COMMAND testbeast)


### PR DESCRIPTION
使用`cmake -DADDON_TYPE=SharedLibrary`可以编译安装共享库版本的插件，默认编译应该没有变化