### PR TITLE
加入Unix socket支持

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,9 @@
-
-if (${ADDON_TYPE} STREQUAL "StaticLibrary")
+if ("${ADDON_TYPE}" STREQUAL "StaticLibrary")
     add_library(beast STATIC beast.cpp)
     target_link_libraries(beast Fcitx5::Core)
 endif()
 
-if (${ADDON_TYPE} STREQUAL "SharedLibrary")
+if ("${ADDON_TYPE}" STREQUAL "SharedLibrary")
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     add_library(beast SHARED beast.cpp)
     target_link_libraries(beast Fcitx5::Core)

--- a/src/beast.h
+++ b/src/beast.h
@@ -1,6 +1,10 @@
 #ifndef _FCITX5_MODULES_BEAST_BEAST_H_
 #define _FCITX5_MODULES_BEAST_BEAST_H_
 
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#define FCITX5_BEAST_HAS_UNIX_SOCKET
+#endif
+
 #include <boost/asio.hpp>
 #include <fcitx-utils/i18n.h>
 #include <fcitx/addonfactory.h>
@@ -13,15 +17,43 @@ namespace asio = boost::asio;
 
 // fcitx in numpad
 #define DEFAULT_PORT 32489
+#define DEFAULT_UNIX_SOCKET_PATH "/tmp/fcitx5.sock"
 
 using ConfigGetter = std::function<std::string(const char *)>;
 using ConfigSetter = std::function<void(const char *, const char *)>;
 
 namespace fcitx {
 
-FCITX_CONFIGURATION(BeastConfig, Option<int, IntConstrain> port{
-                                     this, "Port", _("Port"), DEFAULT_PORT,
-                                     IntConstrain(1024, 65535)};);
+FCITX_CONFIGURATION(BeastTcpConfig, Option<int, IntConstrain> port{
+                                        this, "Port", _("Port"), DEFAULT_PORT,
+                                        IntConstrain(1024, 65535)};);
+
+FCITX_CONFIGURATION(BeastUnixSocketConfig,
+                    Option<std::string> path{this, "Path", _("Path"),
+                                             DEFAULT_UNIX_SOCKET_PATH};);
+
+FCITX_CONFIG_ENUM(BeastCommunication,
+#ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
+                  UnixSocket,
+#endif
+                  Tcp);
+
+FCITX_CONFIGURATION(BeastConfig,
+                    Option<BeastCommunication> communication{
+                        this, "Communication", _("Communication"),
+#ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
+                        BeastCommunication::UnixSocket
+#else
+                        BeastCommunication::Tcp
+#endif
+                    };
+#ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
+                    Option<BeastUnixSocketConfig> unix_socket{this,
+                                                              "Unix Socket",
+                                                              _("Unix Socket"),
+                                                              {}};
+#endif
+                    Option<BeastTcpConfig> tcp{this, "Tcp", _("Tcp"), {}};);
 
 extern ConfigGetter configGetter_;
 extern ConfigSetter configSetter_;

--- a/src/beast.h
+++ b/src/beast.h
@@ -32,11 +32,12 @@ FCITX_CONFIGURATION(BeastUnixSocketConfig,
                     Option<std::string> path{this, "Path", _("Path"),
                                              DEFAULT_UNIX_SOCKET_PATH};);
 
-FCITX_CONFIG_ENUM(BeastCommunication,
+enum class BeastCommunication { UnixSocket, TCP };
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(BeastCommunication,
 #ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
-                  UnixSocket,
+                                 N_("Unix Socket"),
 #endif
-                  Tcp);
+                                 N_("TCP"));
 
 FCITX_CONFIGURATION(BeastConfig,
                     Option<BeastCommunication> communication{
@@ -44,7 +45,7 @@ FCITX_CONFIGURATION(BeastConfig,
 #ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
                         BeastCommunication::UnixSocket
 #else
-                        BeastCommunication::Tcp
+                        BeastCommunication::TCP
 #endif
                     };
 #ifdef FCITX5_BEAST_HAS_UNIX_SOCKET
@@ -53,7 +54,7 @@ FCITX_CONFIGURATION(BeastConfig,
                                                               _("Unix Socket"),
                                                               {}};
 #endif
-                    Option<BeastTcpConfig> tcp{this, "Tcp", _("Tcp"), {}};);
+                    Option<BeastTcpConfig> tcp{this, "TCP", _("TCP"), {}};);
 
 extern ConfigGetter configGetter_;
 extern ConfigSetter configSetter_;

--- a/test/testbeast.cpp
+++ b/test/testbeast.cpp
@@ -27,12 +27,6 @@ int main() {
     auto beast = dynamic_cast<Beast *>(instance.addonManager().addon("beast"));
     assert(beast);
 
-    RawConfig default_port_raw;
-    BeastConfig default_port_cfg;
-    default_port_cfg.communication.setValue(BeastCommunication::Tcp);
-    default_port_cfg.save(default_port_raw);
-    beast->setConfig(default_port_raw);
-
     bool getterCalled = false;
     bool setterCalled = false;
 
@@ -45,28 +39,40 @@ int main() {
         return "";
     });
 
-    // Listen on default port.
-    assert(std::system("lsof -i:32489") == 0);
+    // Listen on default unix socket.
+    assert(std::system("lsof /tmp/fcitx5.sock") == 0);
 
     // Getter works.
     assert(!getterCalled);
-    assert(std::system("curl http://localhost:32489/config/addon/beast") == 0);
+    assert(std::system("curl --unix-socket /tmp/fcitx5.sock "
+                       "http://fcitx/config/addon/beast") == 0);
     assert(getterCalled);
 
     // Setter works.
     assert(!setterCalled);
-    assert(
-        std::system(
-            "curl -X POST -d '{}' http://localhost:32489/config/addon/beast") ==
-        0);
+    assert(std::system("curl --unix-socket /tmp/fcitx5.sock -X POST -d '{}' "
+                       "http://fcitx/config/addon/beast") == 0);
     assert(setterCalled);
 
-    // Port reset works.
+    // Unix socket path reset works.
     auto config = dynamic_cast<const BeastConfig *>(beast->getConfig());
     RawConfig raw;
     config->dumpDescription(raw);
     BeastConfig cfg;
+    cfg.unix_socket.mutableValue()->path.setValue("/tmp/fcitx5-another.sock");
+    cfg.save(raw);
+    beast->setConfig(raw);
+
+    assert(std::system("lsof /tmp/fcitx5.sock") != 0);
+    assert(std::system("lsof /tmp/fcitx5-another.sock") == 0);
+
+    // Tcp default port works.
     cfg.communication.setValue(BeastCommunication::Tcp);
+    cfg.save(raw);
+    beast->setConfig(raw);
+    assert(std::system("lsof -i:32489") == 0);
+
+    // Tcp port reset works.
     cfg.tcp.mutableValue()->port.setValue(32490);
     cfg.save(raw);
     beast->setConfig(raw);

--- a/test/testbeast.cpp
+++ b/test/testbeast.cpp
@@ -72,6 +72,21 @@ int main() {
     beast->setConfig(raw);
     assert(std::system("lsof -i:32489") == 0);
 
+    getterCalled = false;
+    setterCalled = false;
+
+    // Getter works over TCP.
+    assert(!getterCalled);
+    assert(std::system("curl "
+                       "http://127.0.0.1:32489/config/addon/beast") == 0);
+    assert(getterCalled);
+
+    // Setter works ovet TCP.
+    assert(!setterCalled);
+    assert(std::system("curl -X POST -d '{}' "
+                       "http://127.0.0.1:32489/config/addon/beast") == 0);
+    assert(setterCalled);
+
     // Tcp port reset works.
     cfg.tcp.mutableValue()->port.setValue(32490);
     cfg.save(raw);

--- a/test/testbeast.cpp
+++ b/test/testbeast.cpp
@@ -27,6 +27,12 @@ int main() {
     auto beast = dynamic_cast<Beast *>(instance.addonManager().addon("beast"));
     assert(beast);
 
+    RawConfig default_port_raw;
+    BeastConfig default_port_cfg;
+    default_port_cfg.communication.setValue(BeastCommunication::Tcp);
+    default_port_cfg.save(default_port_raw);
+    beast->setConfig(default_port_raw);
+
     bool getterCalled = false;
     bool setterCalled = false;
 
@@ -60,7 +66,8 @@ int main() {
     RawConfig raw;
     config->dumpDescription(raw);
     BeastConfig cfg;
-    cfg.port.setValue(32490);
+    cfg.communication.setValue(BeastCommunication::Tcp);
+    cfg.tcp.mutableValue()->port.setValue(32490);
     cfg.save(raw);
     beast->setConfig(raw);
 

--- a/test/testbeast.cpp
+++ b/test/testbeast.cpp
@@ -67,7 +67,7 @@ int main() {
     assert(std::system("lsof /tmp/fcitx5-another.sock") == 0);
 
     // Tcp default port works.
-    cfg.communication.setValue(BeastCommunication::Tcp);
+    cfg.communication.setValue(BeastCommunication::TCP);
     cfg.save(raw);
     beast->setConfig(raw);
     assert(std::system("lsof -i:32489") == 0);


### PR DESCRIPTION
可配置：

![ui3](https://github.com/fcitx-contrib/fcitx5-beast/assets/2550612/ac890be5-0e23-4d96-86ca-bfd170636349)

强烈建议生产环境使用unix socket通信

uds权限是srwx------，只有本人能访问；随着更多功能的加入，其他用户可能使用tcp操纵im实现keylogger等窃取密码：

[The not-so-silent type - Vulnerabilities across keyboard apps reveal keystrokes to network eavesdroppers.](https://citizenlab.ca/wp-content/uploads/2024/04/CitizenLabReport175-keyboardvuln.pdf)
